### PR TITLE
Refresh cookies functionality

### DIFF
--- a/api/controllers/user.controller.js
+++ b/api/controllers/user.controller.js
@@ -56,6 +56,7 @@ export const deleteUser = async (req, res, next) => {
 
 export const signout = (req, res, next) => {
     try {
+        res.clearCookie('refresh_token')
         res.clearCookie('access_token').status(200).json("User has been signed out")
     } catch (error) {
         next(error)

--- a/api/utils/verifyUser.js
+++ b/api/utils/verifyUser.js
@@ -2,14 +2,29 @@ import jwt from 'jsonwebtoken'
 import {errorHandler} from './error.js'
 export const verifyToken = (req, res, next) => {
     const token = req.cookies.access_token
-    if (!token) {
-        return next(errorHandler(401, 'Unauthorised'))
+    const refresh_token = req.cookies.refresh_token
+    if (!token || !refresh_token) {
+        return next(errorHandler(401, 'Unauthorised, access_token or refresh_token not found'))
     }
     jwt.verify(token, process.env.JWTSECRET, (err, user) => {
-        if (err) {
-            return next(errorHandler(401, 'Unauthorised'))
+        if (err) { // the token has expired, try refresh
+            jwt.verify(refresh_token, process.env.JWTREFRESH, (err, user) => {
+                if (err) { // the refresh token has expired, return an error
+                    return next(errorHandler(401, 'Unauthorised, could not refresh access token, invalid access&refresh token'))
+                }
+                const newAccessToken = jwt.sign({id: user.id, isAdmin: user.isAdmin}, process.env.JWTSECRET, {expiresIn: 8})
+                jwt.verify(newAccessToken, process.env.JWTSECRET, (err, user) => { // retry verification
+                    if (err) {
+                        return next(errorHandler(401, 'Unauthorised, failed to refresh access token'))
+                    } else {
+                        req.user = user
+                        next()
+                    }
+                })                
+            })
+        } else {
+            req.user = user
+            next()
         }
-        req.user = user
-        next()
     })
 }


### PR DESCRIPTION
Had an issue where my Admin credentials would lose access to Admin functionality when I logged back into it the next day, causing me to re-log in every time. Realised that my cookies were being expired, even though they should never expire. Took the chance to create more secure cookies by limiting their lifespan, and fixed the losing admin access issue by utilising refresh tokens.

Now, if a token is unauthorised, it attempts to generate a new token assuming you still have a valid refresh token. 