### PR TITLE
[render preview] In text images - upload button, copy-paste, drag-drop

### DIFF
--- a/client/src/components/DashComments.jsx
+++ b/client/src/components/DashComments.jsx
@@ -17,7 +17,7 @@ export default function DashComments() {
   useEffect(() => {
     const fetchComments = async () => {
       try {
-        const res = await fetch(`/api/comment/getcomments`);
+        const res = await fetch(`/api/comment/getcomments?sort=desc`);
         const data = await res.json();
         if (res.ok) {
           setComments(data.comments);

--- a/client/src/components/DashPosts.jsx
+++ b/client/src/components/DashPosts.jsx
@@ -164,7 +164,7 @@ export default function DashPosts() {
           <div className="text-center">
             <HiOutlineExclamationCircle className="h-14 w-14 text-gray-400 dark:text-gray-200 mb-4 mx-auto" />
             <h3 className="mb-5 text-lg text-gray-500 dark:text-gray-400">
-              Are you sure you want to delete your account?
+              Are you sure you want to delete this post?
             </h3>
           </div>
           <div className="flex justify-center gap-4">

--- a/client/src/components/DashboardComp.jsx
+++ b/client/src/components/DashboardComp.jsx
@@ -37,7 +37,7 @@ export default function DashboardComp() {
         }
         const fetchComments = async () => {
             try {
-                const res = await fetch(`/api/comment/getcomments?limit=5`);
+                const res = await fetch(`/api/comment/getcomments?limit=5&sort=desc`);
                 const data = await res.json();
                 if (res.ok) {
                   setComments(data.comments);

--- a/client/src/pages/CreatePost.jsx
+++ b/client/src/pages/CreatePost.jsx
@@ -205,7 +205,7 @@ export default function CreatePost() {
     }
   }), []);
   return (
-    <div className="p-3 max-w-3xl mx-auto min-h-screen">
+    <div className="p-3 max-w-5xl mx-auto min-h-screen">
       <h1 className="text-center text-3xl my-7 font-semibold">Create a post</h1>
       <form className="flex flex-col gap-4" onSubmit={handleSubmit}>
         <div className="flex flex-col gap-4 sm:flex-row justify-between">
@@ -271,7 +271,8 @@ export default function CreatePost() {
         ref={quillRef}
           theme="snow"
           placeholder="Write something..."
-          className="h-72 mb-12"
+          style={{height: 800}}
+          className="h-120 mb-12"
           required
           onChange={(value) => {
             setFormdata({ ...formdata, content: value });


### PR DESCRIPTION
Added functionality to upload images from within text onto the firebase storage, rather than encoding it into the payload.
This allows for more (almost unlimited) images to be uploaded in-text, and can be done by pressing the upload image button on the textbox ribbon, copy-pasting from online or offline sources, and dragging and dropping onto the textbox.

Also fixed bugs where comments were not being ordered in descending order in the dashboard.